### PR TITLE
feat: add optional theme-aware mode for @darkmode filter

### DIFF
--- a/ImageCache.ts
+++ b/ImageCache.ts
@@ -40,22 +40,23 @@ export class ImageCache {
 			.substring(0, length);
 	}
 
-	cacheName(file: ImageInfo, filterNames: Array<string>): string {
+	cacheName(file: ImageInfo, filterNames: Array<string>, theme?: 'light' | 'dark'): string {
 		const hash = this.getSafeHash(file.path);
 		const name = file.basename.replace(/[^a-zA-Z0-9_-]/g, '_');
-		return `${name}_${hash}_${filterNames.join('_')}.png`;
+		const themeStr = theme ? `_${theme}` : '';
+		return `${name}_${hash}_${filterNames.join('_')}${themeStr}.png`;
 	}
 
-	cachePath(file: ImageInfo, filternames: Array<string>): string {
-		return path.join(this.cacheDir, this.cacheName(file, filternames));
+	cachePath(file: ImageInfo, filternames: Array<string>, theme?: 'light' | 'dark'): string {
+		return path.join(this.cacheDir, this.cacheName(file, filternames, theme));
 	}
 
-	absoluteCachePath(file: ImageInfo, filternames: Array<string>): string {
-		return path.join(this.vaultPath, this.cachePath(file, filternames));
+	absoluteCachePath(file: ImageInfo, filternames: Array<string>, theme?: 'light' | 'dark'): string {
+		return path.join(this.vaultPath, this.cachePath(file, filternames, theme));
 	}
 
-	isFresh(file: ImageInfo, filterNames: string[]): boolean {
-		const cachePath = this.absoluteCachePath(file, filterNames);
+	isFresh(file: ImageInfo, filterNames: string[], theme?: 'light' | 'dark'): boolean {
+		const cachePath = this.absoluteCachePath(file, filterNames, theme);
 		try {
 			if (!fs.existsSync(cachePath)) return false;
 
@@ -66,8 +67,8 @@ export class ImageCache {
 		}
 	}
 
-	clear(file: ImageInfo, filterNames: string[]) {
-		const cachePath = this.absoluteCachePath(file, filterNames);
+	clear(file: ImageInfo, filterNames: string[], theme?: 'light' | 'dark') {
+		const cachePath = this.absoluteCachePath(file, filterNames, theme);
 
 		this.logger.log('[  CACHE  ]   clear: ', cachePath);
 

--- a/README.md
+++ b/README.md
@@ -79,12 +79,32 @@ You can even use image links to remote images:
 
 ### Darkmode
 
-Reccomended for use on images with white backgrounds (e.g. screenshots of diagrams in papers). Invertes the image, removes the background, and boosts the lightness by 1.2
-
-Essentially just a shorthand for: `@invert @transparent(threshold="rgb((13, 13, 13))", remove="below") @boost-lightness(amount=1.2)`.
+Reccomended for use on images with white backgrounds (e.g. screenshots of diagrams in papers).
 
 name: `@darkmode`
 params: none.
+
+#### Default Behavior
+
+By default, always applies dark mode adjustments: inverts the image, removes the background, and boosts the lightness by 1.2.
+
+Essentially just a shorthand for: `@invert @transparent(threshold="rgb((13, 13, 13))", remove="below") @boost-lightness(amount=1.2)`.
+
+#### Theme Aware Mode
+
+You can enable **Theme Aware Mode** in the plugin settings. When enabled, the `@darkmode` filter automatically adapts to Obsidian's current theme:
+
+**In Dark Theme:**
+- Inverts colors
+- Removes dark backgrounds (below threshold)
+- Boosts lightness by 1.2x
+
+**In Light Theme:**
+- Keeps original colors (no inversion)
+- Removes bright backgrounds (above threshold ~240)
+- Reduces lightness by 0.85x to increase contrast
+
+Images will automatically re-render when you switch between light and dark themes.
 
 
 ### Invert

--- a/filters/DarkModeFilter.ts
+++ b/filters/DarkModeFilter.ts
@@ -5,24 +5,49 @@ import { FilterOutput } from "./FilterOutput";
 import { ImageFilter } from "./ImageFilter";
 import { InvertFilter } from "./InvertFilter";
 import { TransparentFilter } from "./TransparentFilter";
+import Color from 'color';
 
 
 export const DarkModeFilterName = "darkmode";
 
 export class DarkModeFilter implements ImageFilter {
     private invertFilter: InvertFilter = new InvertFilter();
-    private transparentFilter: TransparentFilter = new TransparentFilter();
-    private boostLightnessFilter: BoostLightnessFilter = new BoostLightnessFilter();
+    private transparentFilterDark: TransparentFilter = new TransparentFilter();
+    private transparentFilterLight: TransparentFilter;
+    private boostLightnessFilterDark: BoostLightnessFilter = new BoostLightnessFilter();
+    private boostLightnessFilterLight: BoostLightnessFilter;
+
+    constructor() {
+        // For light mode: remove bright backgrounds (above threshold ~240)
+        this.transparentFilterLight = new TransparentFilter(
+            Color('rgb(240, 240, 240)'),
+            "above"
+        );
+        // For light mode: reduce lightness to increase contrast
+        this.boostLightnessFilterLight = new BoostLightnessFilter(0.85);
+    }
 
     getName(): string {
         return DarkModeFilterName;
     }
     
-    processImage(image: FilterInput): FilterOutput {
+    processImage(image: FilterInput, theme?: 'light' | 'dark'): FilterOutput {
         let x: FilterInputOutput = image;
-        x = this.invertFilter.processImage(x);
-        x = this.transparentFilter.processImage(x);
-        x = this.boostLightnessFilter.processImage(x);
+        
+        // If theme is 'light', apply light mode adjustments
+        if (theme === 'light') {
+            // No inversion - keep original colors
+            // Remove bright backgrounds
+            x = this.transparentFilterLight.processImage(x);
+            // Darken slightly for better contrast
+            x = this.boostLightnessFilterLight.processImage(x);
+        } else {
+            // Default behavior (dark mode or no theme specified) - backward compatible
+            x = this.invertFilter.processImage(x);
+            x = this.transparentFilterDark.processImage(x);
+            x = this.boostLightnessFilterDark.processImage(x);
+        }
+        
         return x;
     }
 }

--- a/filters/ImageFilter.ts
+++ b/filters/ImageFilter.ts
@@ -4,5 +4,5 @@ import { FilterOutput } from 'filters/FilterOutput';
 export interface ImageFilter {
 	getName(): string;
 
-	processImage(image: FilterInput): FilterOutput;
+	processImage(image: FilterInput, theme?: 'light' | 'dark'): FilterOutput;
 }


### PR DESCRIPTION
# Add Theme-Aware Mode for @darkmode Filter

## Summary

Adds an optional "Theme Aware Mode" setting that makes the `@darkmode` filter automatically adapt to Obsidian's current theme (light/dark). When enabled, images intelligently adjust their filtering based on whether the user is viewing in light or dark mode.

## Motivation

The `@darkmode` filter works perfectly for dark themes (inverts colors, removes dark backgrounds), but looks poor in light themes where the inversion creates an unnatural appearance. Users who switch between themes had to choose between:
- Always having inverted images (good in dark, bad in light)
- Not using the filter at all

This PR solves that by detecting the active theme and applying appropriate adjustments.

## Changes

### New Feature: Theme Aware Mode
- **OFF by default** - maintains backward compatibility
- When enabled, `@darkmode` filter adapts to current theme:
  - **Dark theme**: Inverts colors, removes dark backgrounds, boosts lightness (existing behavior)
  - **Light theme**: Keeps original colors, removes bright backgrounds, reduces lightness for contrast
- Images automatically update when switching themes

### Implementation Details

**Files Modified:**
- `main.ts` - Added setting, theme detection (`getCurrentTheme()`), MutationObserver for theme changes
- `filters/ImageFilter.ts` - Added optional `theme` parameter to interface
- `filters/DarkModeFilter.ts` - Implemented conditional filtering logic based on theme
- `ImageCache.ts` - Cache keys include theme to maintain separate cached versions
- `README.md` - Documented new feature

**Technical Approach:**
- Detects theme via `body.className` (`theme-light`/`theme-dark` classes)
- MutationObserver watches for theme changes and triggers reprocessing
- Separate cache files per theme prevent unnecessary recomputation
- All filters remain backward compatible (theme parameter is optional)

## Usage

1. Enable "Theme Aware Mode" in plugin settings
2. Use `@darkmode` filter as normal: `![[image.png|@darkmode]]`
3. Images automatically adapt when switching themes

**Example:**

`![image.png|@darkmode]`

- In dark mode: Shows inverted diagram with transparent dark areas
- In light mode: Shows original colors with transparent bright areas

## Testing

- ✅ Builds without errors
- ✅ Default behavior unchanged (backward compatible)
- ✅ Theme detection works for light and dark modes
- ✅ Automatic reprocessing on theme change
- ✅ Cache system creates separate files per theme
- ✅ Setting toggle immediately affects all images

See `TESTING.md` for detailed testing guide.

## Breaking Changes

None. Feature is opt-in and disabled by default.

## Future Enhancements

Potential follow-ups:
- User-configurable threshold values for light mode
- Per-image theme override syntax (e.g., `@darkmode(theme="light")`)
- Additional theme-aware filters beyond darkmode

---

Closes #15
